### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+# easyepg lite runtime dependencies
+# (mirrors the modules listed in the README "Prerequisites" section)
+bottle
+beautifulsoup4
+cheroot
+curl-cffi
+pytz
+requests
+xmltodict


### PR DESCRIPTION
## What

Adds a `requirements.txt` listing the runtime Python modules.

## Why

The dependencies are currently documented only in the README ("Prerequisites") and in `addon.xml` (Kodi). For standalone / Docker / server installs there's no single manifest to install from, which makes it easy to miss a module — in practice `bs4` is commonly missing, causing provider imports (e.g. `resources/lib/providers/zttch.py` → `from bs4 import BeautifulSoup`) to fail with `ModuleNotFoundError`.

With this file a fresh environment is one command away:

```
pip install -r requirements.txt
```

The list mirrors the modules already named in the README:
`bottle, beautifulsoup4, cheroot, curl-cffi, pytz, requests, xmltodict`.